### PR TITLE
Allow to "compress" the edits history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 log/
 output/
 npm-debug.log
+
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "4.2"
+  - "4.1"
+  - "4.0"
+  - "0.12"
+  - "0.10"
+sudo: false
+script: "npm test && npm run-script lint"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ wiki-evolution fo.wikipedia.org
 This will install `wiki-evolution` npm module globally
 and render the visualization for [poznan.wikia.com](http://poznan.wikia.com) and [Faroese Wikipedia](http://fo.wikipedia.org).
 
+For large wikis with a long edits history you can include every N-th edit only:
+
+```
+EDITS_COMPRESSION=150 wiki-evolution muppet.wikia.com
+```
+
+This will include only the first, 150th, 300th, ... edit of each article.
+
 ## Genesis
 
 Port of [WikiEvolution extension](https://github.com/Wikia/app/tree/dev/extensions/wikia/hacks/WikiEvolution)

--- a/bin/wiki-evolution.sh
+++ b/bin/wiki-evolution.sh
@@ -37,7 +37,7 @@ echo
 # call wiki2gource
 if [ ! -f $input ]; then
 	echo "Calling wiki2gource..."
-	/usr/bin/env node $dir/wiki2gource.js $wikiname | sort > $input
+	/usr/bin/env node $dir/wiki2gource.js $wikiname $EDITS_COMPRESSION | sort > $input
 else
 	echo "$input exists, remove to regenerate"
 fi

--- a/bin/wiki2gource.js
+++ b/bin/wiki2gource.js
@@ -22,8 +22,11 @@ var config = {
 // init the MediaWiki client
 var server = process.argv[2] || false;
 
+// for large wikis allow to include every N-th edit only
+var editsCompression = parseInt(process.argv[3], 10) || 0;
+
 if (!server) {
-	console.error('Usage: wiki2gource <wiki domain>');
+	console.error('Usage: wiki2gource <wiki domain> [editsCompression]');
 	process.exit(1);
 }
 
@@ -121,6 +124,14 @@ async.parallel(
 					color = colorsRanker.getColorForEdit(revisions.length - 1);
 
 					console.error('%s [%d edits]...', articlePath, revisions.length);
+
+					if (editsCompression) {
+						revisions = revisions.filter(function(item, index) {
+							return index % editsCompression === 0;
+						});
+
+						console.error('%s [%d edits after compression]...', articlePath, revisions.length);
+					}
 
 					// generate entries for all revisions
 					revisions.forEach(function(rev) {

--- a/bin/wiki2gource.js
+++ b/bin/wiki2gource.js
@@ -50,6 +50,10 @@ client = new nodemw({
 // @see https://github.com/caolan/async#paralleltasks-callback
 console.error('Getting wiki statistics...');
 
+if (editsCompression) {
+	console.error('Edits compression of %d will be applied', editsCompression);
+}
+
 async.parallel(
 	{
 		// get wiki statistics

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "color": "^0.8.0",
-    "nodemw": "^0.6.0"
+    "nodemw": "^0.8.0"
   },
   "devDependencies": {
     "jshint": "^2.6.3",


### PR DESCRIPTION
```
EDITS_COMPRESSION=150 wiki-evolution muppet.wikia.com

Calling wiki2gource...
Getting wiki statistics...
Edits compression of 150 will be applied
This wikis has 832552 edits on 28640 articles
Using 210 categories to build a wiki tree
```

Fixes #7
