### PR TITLE
Update Dockerfile: use node:lts-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node?tab=tags&page=1&name=slim
-FROM node:slim
+FROM node:lts-slim
 
 RUN apt-get update && \
 	apt-get install -y gource ffmpeg xvfb


### PR DESCRIPTION
## Before

```
REPOSITORY                      TAG       IMAGE ID       CREATED        SIZE
ghcr.io/macbre/wiki-evolution   latest    4f6f857aacaa   1 second ago   916MB
```